### PR TITLE
Updates installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,18 @@
 After a successful build, tell SpeedCurve you've deployed and trigger a round of testing.
 
 ## Usage
-1. Install the plugin using `npm`:
+1. Add the following lines to your `netlify.toml` configuration file:
 
-```
-npm i netlify-build-plugin-speedcurve
-```
-
-2. Update your `netlify.yml` configuration file to reference the plugin in your plugins section:
-
-```yml
-build:
-  ...
-
-plugins:
-  - type: netlify-build-plugin-speedcurve
+```toml
+[[plugins]]
+package = "netlify-build-plugin-speedcurve"
 ```
 
-3. Grab your [SpeedCurve API Key (Admin > Teams)](https://speedcurve.com/admin/teams) and the ID for the site you want to test (under Settings > Sites) and store them as environmental variables inside of Netlify. *At the moment, Netlify Build plugins are in private beta so you'll need to [work with the Netlify folks to get build plugins enabled](https://forms.gle/RemZEGP35P8fEL848).*
+Note: The `[[plugins]]` line is required for each plugin, even if you have other plugins in your `netlify.toml` file already.
 
-4. Using the latest version of the Netlify CLI, run a dry build:
+2. Grab your [SpeedCurve API Key (Admin > Teams)](https://speedcurve.com/admin/teams) and the ID for the site you want to test (under Settings > Sites) and store them as environmental variables inside of Netlify. *At the moment, Netlify Build plugins are in private beta so you'll need to [work with the Netlify folks to get build plugins enabled](https://forms.gle/RemZEGP35P8fEL848).*
+
+3. Using the latest version of the Netlify CLI, run a dry build:
 
 ```
 netlify build --dry


### PR DESCRIPTION
For greater simplicity and consistency with Netlify users’ existing configuration files, we’re deprecating experimental support for Netlify config files in YAML or JSON (https://github.com/netlify/build/issues/975).

To get new plugin users started on the right foot, I’m proposing updates for all plugin READMEs to use `netlify.toml` format in the installation instructions.

**This docs-only change should require no updates to your plugin code.**

I've also made the following updates to reflect the current plugins API:
- Replaced `type` with `package`.
- Removed `npm install` step. This is no longer necessary.