### PR TITLE
fix: switch to failPlugin instead of failBuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const {
 const fetch = require('node-fetch');
 
 module.exports = {
-    async onSuccess({ utils: { build: { failPlugin, failBuild } } }) {
+    async onSuccess({ utils: { build: { failPlugin } } }) {
         console.log('Preparing to trigger SpeedCurve tests');
 
         try {
@@ -35,7 +35,7 @@ module.exports = {
 
             console.log('SpeedCurve test submitted!');
         } catch (error) {
-            return failBuild('SpeedCurve test failed', { error })
+            return failPlugin('SpeedCurve test failed', { error })
         }
     }
 }


### PR DESCRIPTION
Hi @tkadlec and thanks for creating this plugin!

We're making a change to how `onSuccess` works.

**Current:**  `onSuccess` occurs after the build command is complete, but before any files are uploaded.
**Upcoming:** `onSuccess`  occurs after the site is deployed, live, and published to production (if applicable).

As a result `onSuccess` can no longer be used to fail the build, hence the change to `failPlugin`.

Since it seems this plugin triggers an async analysis it would make sense to use `failPlugin` (if I'm not mistaken).